### PR TITLE
Take into account multiple AMD GPUs on the same device

### DIFF
--- a/src/adjustor/fuse/gpu.py
+++ b/src/adjustor/fuse/gpu.py
@@ -3,7 +3,7 @@ import os
 from typing import Literal, NamedTuple
 from typing import Sequence
 
-from adjustor.fuse.utils import find_amd_igpu, find_intel_igpu
+from adjustor.fuse.utils import find_amd_igpu
 
 logger = logging.getLogger(__name__)
 GPU_FREQUENCY_PATH = "device/pp_od_clk_voltage"

--- a/src/adjustor/fuse/gpu.py
+++ b/src/adjustor/fuse/gpu.py
@@ -3,7 +3,7 @@ import os
 from typing import Literal, NamedTuple
 from typing import Sequence
 
-from adjustor.fuse.utils import find_igpu as find_amd_igpu
+from adjustor.fuse.utils import find_amd_igpu, find_intel_igpu
 
 logger = logging.getLogger(__name__)
 GPU_FREQUENCY_PATH = "device/pp_od_clk_voltage"
@@ -37,29 +37,6 @@ class GPUStatus(NamedTuple):
     cpu_boost: bool | None
     epp_avail: Sequence[EppStatus] | None
     epp: EppStatus | None
-
-
-def find_intel_igpu():
-    for hw in os.listdir("/sys/class/drm"):
-        if not hw.startswith("card"):
-            continue
-        if not os.path.exists(f"/sys/class/drm/{hw}/device/subsystem_vendor"):
-            continue
-        with open(f"/sys/class/drm/{hw}/device/subsystem_vendor", "r") as f:
-            # intel
-            if "1462" not in f.read():
-                continue
-
-        if not os.path.exists(f"/sys/class/drm/{hw}/device/local_cpulist"):
-            logger.warning(
-                f'No local_cpulist found for "{hw}". Assuming it is a dedicated unit.'
-            )
-            continue
-
-        pth = os.path.realpath(os.path.join("/sys/class/drm", hw))
-        return pth
-
-    return None
 
 
 def get_igpu_status():

--- a/src/adjustor/fuse/gpu.py
+++ b/src/adjustor/fuse/gpu.py
@@ -38,6 +38,7 @@ class GPUStatus(NamedTuple):
     epp_avail: Sequence[EppStatus] | None
     epp: EppStatus | None
 
+
 def find_intel_igpu():
     for hw in os.listdir("/sys/class/drm"):
         if not hw.startswith("card"):

--- a/src/adjustor/fuse/utils.py
+++ b/src/adjustor/fuse/utils.py
@@ -224,26 +224,3 @@ def start_tdp_client(
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     prepare_tdp_mount(True)
-
-
-def find_intel_igpu():
-    for hw in os.listdir("/sys/class/drm"):
-        if not hw.startswith("card"):
-            continue
-        if not os.path.exists(f"/sys/class/drm/{hw}/device/subsystem_vendor"):
-            continue
-        with open(f"/sys/class/drm/{hw}/device/subsystem_vendor", "r") as f:
-            # intel
-            if "1462" not in f.read():
-                continue
-
-        if not os.path.exists(f"/sys/class/drm/{hw}/device/local_cpulist"):
-            logger.warning(
-                f'No local_cpulist found for "{hw}". Assuming it is a dedicated unit.'
-            )
-            continue
-
-        pth = os.path.realpath(os.path.join("/sys/class/drm", hw))
-        return pth
-
-    return None

--- a/src/adjustor/fuse/utils.py
+++ b/src/adjustor/fuse/utils.py
@@ -13,7 +13,7 @@ TDP_MOUNT = "/run/hhd-tdp/hwmon"
 FUSE_MOUNT_SOCKET = "/run/hhd-tdp/socket"
 
 
-def _get_vulkaninfo_output():
+def _get_vulkaninfo_output() -> str:
     result = subprocess.run(["vulkaninfo", "--summary"], capture_output=True, text=True)
     return result.stdout
 
@@ -39,7 +39,7 @@ def _uuid_to_pci_address(uuid: str) -> Optional[str]:
     if len(bus_hex_le) != 4:
         return None
 
-    bus_hex = bus_hex_le[2:] + bus_hex_le[:2]  # '6400' → '0064'
+    bus_hex = bus_hex_le[2:] + bus_hex_le[:2]
     bus = int(bus_hex, 16)
 
     return f"0000:{bus:02x}:00.0"

--- a/src/adjustor/fuse/utils.py
+++ b/src/adjustor/fuse/utils.py
@@ -234,26 +234,3 @@ def start_tdp_client(
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     prepare_tdp_mount(True)
-
-
-def find_intel_igpu():
-    for hw in os.listdir("/sys/class/drm"):
-        if not hw.startswith("card"):
-            continue
-        if not os.path.exists(f"/sys/class/drm/{hw}/device/subsystem_vendor"):
-            continue
-        with open(f"/sys/class/drm/{hw}/device/subsystem_vendor", "r") as f:
-            # intel
-            if "1462" not in f.read():
-                continue
-
-        if not os.path.exists(f"/sys/class/drm/{hw}/device/local_cpulist"):
-            logger.warning(
-                f'No local_cpulist found for "{hw}". Assuming it is a dedicated unit.'
-            )
-            continue
-
-        pth = os.path.realpath(os.path.join("/sys/class/drm", hw))
-        return pth
-
-    return None

--- a/src/adjustor/fuse/utils.py
+++ b/src/adjustor/fuse/utils.py
@@ -21,7 +21,7 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 AMD_DGPU_KEYWORDS = [
-    "navi", "radeon", "rx", "vega", "5700", "6600", "6800", "6900", "7900"
+    "navi", "radeon", "rx", "vega"
 ]
 
 def _is_amd_dgpu(pci_address: str) -> bool:


### PR DESCRIPTION
This PR addresses the issue described in [#170](https://github.com/hhd-dev/hhd/issues/170).

Previously, the code iterated over /sys/class/hwmon and selected the first AMD GPU it encountered, which could mistakenly identify a discrete GPU (dGPU) instead of the integrated GPU (iGPU).

This patch improves detection by resolving the full path of each hwmon device and extracting its associated PCI address. We then use lspci to check whether the device matches known AMD dGPU patterns. Only if the device is not a known dGPU do we consider it a valid iGPU candidate.

This should ensure more reliable and deterministic selection of the iGPU on systems with both AMD integrated and discrete GPUs.

I have also moved the `find_intel_igpu` function to utils.py for consistency.